### PR TITLE
Update AudioPlayer.m

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/rctaudiotoolkit/AudioPlayerModule.java
+++ b/android/src/main/java/com/reactnativecommunity/rctaudiotoolkit/AudioPlayerModule.java
@@ -373,7 +373,7 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
 
             player.setPlaybackParams(params);
 
-            if (needToPauseAfterSet) {
+            if (needToPauseAfterSet && player.isPlaying()) {
                 player.pause();
             }
         }

--- a/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
+++ b/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
@@ -139,7 +139,7 @@ RCT_EXPORT_METHOD(prepare:(nonnull NSNumber*)playerId
     }
     NSNumber *mixWithOthers = [options objectForKey:@"mixWithOthers"];
     NSError *error = nil;
-    [[AVAudioSession sharedInstance] setCategory: avAudioSessionCategory withOptions: mixWithOthers ? AVAudioSessionCategoryOptionMixWithOthers : 0 error: &error];
+    [[AVAudioSession sharedInstance] setCategory: avAudioSessionCategory withOptions: mixWithOthers.intValue > 0 ? AVAudioSessionCategoryOptionMixWithOthers : 0 error: &error];
     if (error) {
         NSDictionary* dict = [Helpers errObjWithCode:@"preparefail"
                                          withMessage:@"Failed to set audio session category."];


### PR DESCRIPTION
Simple fix for the mixWithOthers setting in AudioPlayer.m. The current implementation attempts to treat it as a boolean, resulting in mixWithOthers always being set to true. NSNumber in Objective C doesn't do this comparison properly so instead just need to compare it as an integer.

This became a problem when I tried to integrate with react-native-music-control, which requires mixWithOthers to be false.